### PR TITLE
various enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 node_modules
 ca.*
 client.*
+client2.*
 server.*

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following ports will be mapped to localhost on your Docker host:
 
 * 1883: MQTT in the clear
 * 8883: MQTT over TLS
-* 18083: EMQX Dashboard (admin/admin)
+* 18083: EMQX Dashboard (admin/public)
 
 Use `tail -f` inside the `mqtt5-proxy-1` container to monitor the `mqtt_access.log` and `mqtt_error.log` files in `/var/log/nginx` and see how incoming MQTT connections are processed.
 

--- a/mtls/certs.sh
+++ b/mtls/certs.sh
@@ -1,5 +1,6 @@
 CA_NAME=TEST_CA
-CLIENT="std stationId"
+CLIENT1="std station01"
+CLIENT2="std station02"
 cd /mtls
 
 # Install mosquitto clients
@@ -20,8 +21,13 @@ openssl x509 -in server.crt -text -noout
 
 
 # Create the client’s key and certificate; Creating the CSR with the arbitrary Common Name of client
-openssl req -newkey rsa:4096 -keyout client.key -out client.csr -nodes -days 365 -subj "/CN=$CLIENT"
+openssl req -newkey rsa:4096 -keyout client.key -out client.csr -nodes -days 365 -subj "/CN=$CLIENT1"
 # Creating the client’s certificate
 openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -days 365 -out client.crt
 # Inspect ...
 openssl x509 -in client.crt -text -noout
+
+# Create the client’s key and certificate; Creating the CSR with the arbitrary Common Name of client
+openssl req -newkey rsa:4096 -keyout client2.key -out client2.csr -nodes -days 365 -subj "/CN=$CLIENT2"
+# Creating the client’s certificate
+openssl x509 -req -in client2.csr -CA ca.crt -CAkey ca.key -CAcreateserial -days 365 -out client2.crt

--- a/mtls/test.sh
+++ b/mtls/test.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-mosquitto_pub -d -h localhost -t "topic/test" -m "test123" -V mqttv5 --cafile ca.crt --cert client.crt --key client.key -p 8883 -i tcp-aif-stationId -u user -P pass
+mosquitto_pub -d -h localhost -t "topic/test" -m "test123" -V mqttv5 --cafile ca.crt --cert client2.crt --key client2.key -p 8883 -i tcp-aif-station02 -u user -P pass

--- a/mtls/test1883.sh
+++ b/mtls/test1883.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-mosquitto_pub -d -h localhost -t "topic/test" -m "test123" -V mqttv5 -p 1883 -i tcp-aif-stationId -u user -P pass
+mosquitto_pub -d -h localhost -t "topic/test" -m "test123" -V mqttv5 -p 1883 -i tcp-aif-station02 -u user -P pass

--- a/njs/libmqtt.js
+++ b/njs/libmqtt.js
@@ -351,7 +351,7 @@ function getInt16(packet) {
 // Read the next 4 bytes in the buffer as a 32 bit Big Endian Integer
 function getInt32(packet) {
     var value = packet.data.readInt32BE([packet.offset++]);
-    packet.offset++;
+    packet.offset += 3;
     return value;
 }
 

--- a/njs/libmqtt.js
+++ b/njs/libmqtt.js
@@ -1,0 +1,267 @@
+//@ts-check
+/// <reference path="../node_modules/njs-types/ngx_stream_js_module.d.ts" />
+
+export default { packetType, getPacketType, parsePacket, newConnect }
+
+// Enumeration of MQTT Control packets. Correct for v5, but type 15 is reserved in v3.1.1
+var packetType = Object.freeze({
+    CONNECT: 1,
+    CONNACK: 2,
+    PUBLISH: 3,
+    PUBACK: 4,
+    PUBREC: 5,
+    PUBREL: 6,
+    PUBCOMP: 7,
+    SUBSCRIBE: 8,
+    SUBACK: 9,
+    UNSUBSCRIBE: 10,
+    UNSUBACK: 11,
+    PING: 12,
+    PINGRES: 13,
+    DISCONNECT: 14,
+    AUTH: 15,
+    value: {1: "CONNECT", 2: "CONNACK", 3: "PUBLISH", 4: "PUBACK", 5: "PUBREC", 6: "PUBREL",
+            7: "PUBCOMP", 8: "SUBSCRIBE", 9: "SUBACK", 10: "UNSUBSCRIBE", 11: "UNSUBACK",
+            12: "PING", 13: "PINGRES", 14: "DISCONNECT", 15: "AUTH" }
+} );
+
+// Enumeration of MQTT versions. Supported versions are 3.1.1 and 5.0
+var mqttVersion = Object.freeze({
+    V500: 5,
+    V311: 4,
+    V310: 3,
+    value: {3: "V310", 4: "V311", 5: "V500"},
+    support: {4: true, 5: true} 
+});
+
+/**
+ * @param {Object} packet
+ **/
+// Get the Packet Type
+function getPacketType(packet) {
+    packet.type = packet.typeFlags >>4
+    packet.flags = packet.typeFlags &15
+    if ( packet.type == packetType.PUBLISH) {
+        packet.ret = packet.flags & 1
+        packet.qos = packet.flags >> 1 & 3
+        packet.dup = packet.flags >> 3 & 1
+    }
+}
+
+/**
+ * @param {NginxStreamRequest} s
+ * @param {Buffer} data
+ **/
+// parse MQTT packet
+function parsePacket(s, data) {
+
+    var packet = {
+        data: data,
+        offset: 0,
+        typeFlags: 0,
+        type: 0,
+        flags: 0,
+        ret: 0,
+        qos: 0,
+        dup: 0,
+        version: 0,
+        payloadLength: 0,
+        length: 0
+    };
+
+    // Get Type and Flags on packet
+    packet.typeFlags = data[packet.offset++];
+    getPacketType(packet);
+
+    // Length of Variable Header plus length of the Payload.
+    packet.payloadLength = decodeLength(packet);
+    packet.length = packet.payloadLength + packet.offset; 
+
+    switch (packet.type) {
+        case packetType.CONNECT:
+            parseConnect(s, packet)
+            break;
+        default:
+            s.log("Unimplemented Packet " + packetType.value[packet.type] + ", " + packet.type);
+            break;
+    }
+
+    return packet;
+}
+
+/**
+ * @param {NginxStreamRequest} s
+ * @param {Object} packet
+ **/
+// parse MQTT Connect packet
+function parseConnect(s, packet) {
+
+    s.log("Connect Packet Length = " + packet.payloadLength);
+
+    // Verify protocol name and store version
+    // Abort if not MQTT Connect
+    var mqttVerString = cutField(packet);
+    packet.version = packet.data[packet.offset++]
+    if ( (mqttVerString != "MQTT") && (mqttVerString != "MQIsdp")  ) {
+        s.log("ABORT: Packet not MQTT");
+        throw new Error("Connection Rejected");
+    }
+
+    // Reject unsupported versions here.
+    if ( mqttVersion.support[packet.version] != true ) {
+        s.log("ABORT: Packet version not supported: " + mqttVersion.value[packet.version]);
+        throw new Error("Connection Rejected");
+    }
+
+    // Retrieve Connect Flags and Keep Alive
+    packet.connect = {
+        flags: packet.data[packet.offset++]
+    };
+
+    s.log("Connect Flags = " + packet.connect.flags.toString(2));
+
+    if (packet.connect.flags & 2) s.log("Clean Start flag is set");
+
+    packet.connect.varHeaderStart = packet.offset;
+
+    s.log("Keep Alive = " + getInt16(packet));
+
+    // Skip over CONNECT Properties on V5. Store the offset and length incase
+    // we want to inspect or modify later
+    if ( packet.version == mqttVersion.V500) {
+        packet.connect.propLength = decodeLength(packet);
+        s.log("CONNECT Properties  = " + packet.connect.propLength + " bytes");
+        packet.connect.propStart = packet.offset;
+        packet.offset += packet.connect.propLength;
+    }
+    
+    // Get Client Identifier
+    packet.connect.clientID = cutField(packet);
+    s.log("ClientId value   = " + packet.connect.clientID);
+
+    // Store Will Message
+    if (packet.connect.flags & 4) {
+
+        // Skip over will properties, but store offset and length for later
+        if (packet.version == mqttVersion.V500) {
+            packet.connect.willPropLength = decodeLength(packet);
+            s.log("Will Properties  = " + packet.connect.willPropLength + " bytes");
+            packet.connect.willPropStart = packet.offset;
+            packet.offset += packet.connect.willPropLength;
+        }
+
+        // Make these variables global to share with NGINX
+        packet.connect.willTopic = cutField(packet);
+        s.log("Will Topic = " + packet.connect.willTopic);
+
+        packet.connect.willMsg = cutField(packet);
+        s.log("Will Payload = " + packet.connect.willMsg);
+    }
+
+    // End of variable section. Store locations for user/password overwrite use-cases
+    packet.connect.varHeaderEnd = packet.offset;
+
+    // Look for existing username/password
+    if (packet.connect.flags & 128) {
+        packet.connect.username = cutField(packet);
+        s.log("Client User Name = " + packet.connect.username);
+    }
+
+    if (packet.connect.flags & 64) {
+        packet.connect.password = cutField(packet);
+        s.log("Client Password = " + packet.connect.password);
+    }
+    s.log("Expected length: " + packet.length + " Parsed Length: " + packet.offset);
+}
+
+// Create a new CONNECT message based on modified user/password fields
+function newConnect(packet) {
+    var newHeader = packet.data.subarray(packet.connect.varHeaderStart, packet.connect.varHeaderEnd);
+    var newLength = newHeader.length;
+    var newFields = [newHeader];
+
+    if (packet.connect.flags & 128) {
+        var userBuf = setField(packet.connect.username);
+        newLength += userBuf.length;
+        newFields.push(userBuf);
+    }
+
+    if (packet.connect.flags & 64) {
+        var passBuf = setField(packet.connect.password);
+        newLength += passBuf.length;
+        newFields.push(passBuf);
+    }
+
+    newFields.unshift(Buffer.from(setField("MQTT").toString('hex') + pad(packet.version) + packet.connect.flags.toString(16), 'hex'));
+    newLength += 8;
+
+    newFields.unshift(Buffer.from(packet.typeFlags.toString(16) + encodeLength(newLength), 'hex'));
+
+    return Buffer.concat(newFields);
+}
+
+// Internal functions
+
+// Zero pad one digit number
+function pad(n) { return n < 10 ? '0' + n : n }
+
+// Read the next two bytes in the buffer as a 16 bit Big Endian Integer
+function getInt16(packet) {
+    var value = packet.data.readInt16BE([packet.offset++]);
+    packet.offset++;
+    return value;
+}
+
+// Generate variable byte integer
+function encodeLength(length) {
+    var encodedByte = 0;
+    var vbi = "";
+    do {
+        encodedByte = length % 128;
+        length = ~~(length / 128);
+        // if there are more data to encode, set the top bit of this byte
+        if (length > 0) {
+            encodedByte = encodedByte | 128;
+        }
+        vbi += pad(encodedByte.toString(16));
+    } while (length > 0);
+    return vbi;
+}
+
+// Decode variable byte integer
+function decodeLength(packet) {
+    var multiplier = 1;
+    var value = 0;
+    var encodedByte;
+    do {
+        encodedByte = packet.data[packet.offset];
+        value += (encodedByte & 127) * multiplier;
+        if (multiplier > 128 * 128 * 128) {
+            throw new Error("Malformed Variable Byte Integer");
+        }
+        multiplier *= 128;
+    } while ((packet.data[packet.offset++] & 128) != 0);
+    return value;
+}
+
+/**
+ * @param {Object} packet
+ **/
+// Extract Field from buffer based on length defined by 2-byte encoding
+function cutField(packet) {
+    var length = getInt16(packet);
+    var fieldValue = packet.data.toString('utf8', packet.offset, packet.offset + length);
+    packet.offset += length;
+    return fieldValue;
+}
+
+// Create a buffer for a field and prepend its 2-byte encoded length
+function setField(fieldValue) {
+    var length = Buffer.byteLength(fieldValue);
+    var fieldBuffer = Buffer.alloc(length + 2);
+    fieldBuffer.writeInt16BE(length);
+    fieldBuffer.write(fieldValue, 2);
+    return fieldBuffer;
+}
+
+

--- a/njs/proxy.js
+++ b/njs/proxy.js
@@ -1,46 +1,11 @@
+import mqtt from "libmqtt.js";
+
 //@ts-check
 /// <reference path="../node_modules/njs-types/ngx_stream_js_module.d.ts" />
 
 // Global variables
-var packetType = Object.freeze({
-    CONNECT: 1,
-    CONNACK: 2,
-    PUBLISH: 3,
-    PUBACK: 4,
-    PUBREC: 5,
-    PUBREL: 6,
-    PUBCOMP: 7,
-    SUBSCRIBE: 8,
-    SUBACK: 9,
-    UNSUBSCRIBE: 10,
-    UNSUBACK: 11,
-    PING: 12,
-    PINGRES: 13,
-    DISCONNECT: 14,
-    AUTH: 15,
-    value: {1: "CONNECT", 2: "CONNACK", 3: "PUBLISH", 4: "PUBACK", 5: "PUBREC", 6: "PUBREL",
-            7: "PUBCOMP", 8: "SUBSCRIBE", 9: "SUBACK", 10: "UNSUBSCRIBE", 11: "UNSUBACK",
-            12: "PING", 13: "PINGRES", 14: "DISCONNECT", 15: "AUTH" }
-} );
-
-var retain = 0;
-var duplicate = 0;
-var qos = 0;
-
-// Variables parsed from MQTT message.
-var packetTypeFlags = 0;
-var clientID = "-";
-var connectFlags = 0;
-var username = "";
-var password = "";
-
-// Keep track of how many messages we get
+var clientID = "";
 var client_messages = 1;
-
-// These are pointers into the buffer containing the MQTT message
-var offset = 0;
-var varHeaderStart = 0;
-var varHeaderEnd = 0;
 
 /**
  * @param {NginxStreamRequest} s
@@ -49,25 +14,28 @@ var varHeaderEnd = 0;
 function filterMQTT(s) {
     // Main loop to process inbound packets
     s.on('upstream', function (data, flags) {
-        offset = 0;
+
+        var packet = {};
         if (data.length == 0) {  // Initial calls may contain no data, so
             s.log("No buffer yet"); // ask that we get called again
             return;
+        } else {
+            packet = mqtt.parsePacket(s, data);
+        }
 
-        } else if (client_messages == 1) { // CONNECT is first packet from the client
+        if (client_messages == 1) {
+            if (packet.type = mqtt.packetType.CONNECT) { // CONNECT is first packet from the client
 
-            packetTypeFlags = data[offset++];
-            s.log("MQTT packet type+flags = " + getPacketType(packetTypeFlags));
+                s.log("MQTT packet type+flags = " + packet.typeFlags);
 
-            // CONNECT packet is 1, using upper 4 bits (00010000 to 00011111)
-            if (packetTypeFlags >= 16 && packetTypeFlags < 32) {
-
-                // Parse incoming CONNECT message from client
-                parseConnect(s, data);
                 // @ts-ignore
-                s.variables.clientid = clientID;
+                s.variables.clientid = packet.connect.clientID;
+
+                // track clientID across packets.
+                clientID = packet.connect.clientID;
+
                 // @ts-ignore
-                s.variables.username = username;
+                s.variables.username = packet.connect.username;
 
                 // @ts-ignore
                 if (s.variables.filter_connect_ssl_dn == 1) {
@@ -76,22 +44,22 @@ function filterMQTT(s) {
                     s.log("Subject DN value = " + s.variables.ssl_client_s_dn);
 
                     // Compare to MQTT client ID and reject connection if they don't match
-                    if (clientID.substr(-9) != s.variables.ssl_client_s_dn.substr(-9)) {
+                    if (packet.connect.clientID.substr(-9) != s.variables.ssl_client_s_dn.substr(-9)) {
                         s.log("ACCESS DENIED: ClientId/Subject Mismatch");
                         throw new Error("Connection Rejected");
                     }
 
                     // Add a "username" field or overwrite existing
-                    connectFlags |= 128;  // Bit 7
-                    username = s.variables.ssl_client_s_dn;
+                    packet.connect.flags |= 128;  // Bit 7
+                    packet.connect.username = s.variables.ssl_client_s_dn;
                     // @ts-ignore
-                    s.variables.username = username; // Share this variable with NGINX for logging
+                    s.variables.username = packet.connect.username; // Share this variable with NGINX for logging
 
                     // Remove "password" field if desired
-                    connectFlags &= ~64;  // Bit 6
+                    packet.connect.flags &= ~64;  // Bit 6
 
                     // Create and send new CONNECT Message
-                    var newMsg = newConnect(data);
+                    var newMsg = mqtt.newConnect(packet);
                     s.send(newMsg, flags);
                 } else {
                     s.send(data, flags);
@@ -104,12 +72,11 @@ function filterMQTT(s) {
                 }
 
             } else {
-                s.log("ABORT: Received unexpected MQTT packet type+flags: " + packetTypeFlags.toString());
+                s.log("ABORT: Received unexpected MQTT packet type+flags: " + packet.typeFlags.toString());
                 throw new Error("Connection Rejected");
             }
         } else { // Continue processing messages from clients when s.variables.filter_all == 1
-            packetTypeFlags = data[offset++];
-            s.log("MQTT packet: " + clientID +"(" + client_messages  +") type+flags = " + getPacketType(packetTypeFlags));
+            s.log("MQTT packet: " + clientID + "(" + client_messages + ") type+flags = " + mqtt.packetType.value[packet.type]);
             s.send(data, flags);
         }
         client_messages++;
@@ -120,200 +87,38 @@ function filterMQTT(s) {
 function prereadMQTT(s) {
     // Main loop to process inbound packets
     s.on('upstream', function (data, flags) {
+        
+        var packet = {};
         if (data.length == 0) {  // Initial calls may contain no data, so
             s.log("No buffer yet"); // ask that we get called again
             return;
+        } else {
+            packet = mqtt.parsePacket(s, data);
+        }
 
-        } else if (client_messages == 1) { // CONNECT is first packet from the client
+        if (client_messages == 1) { // CONNECT is first packet from the client
 
-            packetTypeFlags = data[offset++];
-            s.log("MQTT packet type+flags = " + packetTypeFlags.toString(2));
+            s.log("MQTT packet type+flags = " + packet.typeFlags.toString(2));
 
             // CONNECT packet sets bit 5, upper 4 bits (00010000 to 00011111) reserved
-            if (packetTypeFlags >= 16 && packetTypeFlags < 32) {
-
-                // Parse incoming CONNECT message from client
-                parseConnect(s, data);
+            if (packet.type = mqtt.packetType.CONNECT) {
 
                 // Copy njs variables to NGINX variables
                 // @ts-ignore
-                s.variables.clientid = clientID;
+                s.variables.clientid = packet.connect.clientID;
                 // @ts-ignore
-                s.variables.username = username;
+                s.variables.username = packet.connect.username;
 
                 s.off('upstream');
 
             } else {
-                s.log("Received unexpected MQTT packet type+flags: " + packetTypeFlags.toString());
+                s.log("Received unexpected MQTT packet type+flags: " + packet.typeFlags.toString());
                 throw new Error("Connection Rejected");
             }
         }
         client_messages++;
         s.allow();
     });
-}
-
-// Internal functions
-
-// Zero pad one digit number
-function pad(n) { return n < 10 ? '0' + n : n }
-
-// Read the next two bytes in the buffer as a 16 bit Big Endian Integer
-function getInt16(data) {
-    var value = data.readInt16BE([offset++]);
-    offset++;
-    return value;
-}
-
-// Generate variable byte integer
-function encodeLength(length) {
-    var encodedByte = 0;
-    var vbi = "";
-    do {
-        encodedByte = length % 128;
-        length = ~~(length / 128);
-        // if there are more data to encode, set the top bit of this byte
-        if (length > 0) {
-            encodedByte = encodedByte | 128;
-        }
-        vbi += pad(encodedByte.toString(16));
-    } while (length > 0);
-    return vbi;
-}
-
-// Decode variable byte integer
-function decodeLength(data) {
-    var multiplier = 1;
-    var value = 0;
-    var encodedByte;
-    do {
-        encodedByte = data[offset];
-        value += (encodedByte & 127) * multiplier;
-        if (multiplier > 128 * 128 * 128) {
-            throw new Error("Malformed Variable Byte Integer");
-        }
-        multiplier *= 128;
-    } while ((data[offset++] & 128) != 0);
-    return value;
-}
-
-// Get the Packet Type
-function getPacketType(typeflags) {
-    let pt = packetType.value[typeflags >>4]
-    let flags = typeflags &15
-    if ( pt == packetType.PUBLISH) {
-        retain = flags & 1
-        qos = flags >> 1 & 3
-        duplicate = flags >> 3 & 1
-    }
-    return pt;
-}
-
-// Extract Field from buffer based on length defined by 2-byte encoding
-function cutField(data) {
-    var length = getInt16(data);
-    var fieldValue = data.toString('utf8', offset, offset + length);
-    offset += length;
-    return fieldValue;
-}
-
-// Create a buffer for a field and prepend its 2-byte encoded length
-function setField(fieldValue) {
-    var length = Buffer.byteLength(fieldValue);
-    var fieldBuffer = Buffer.alloc(length + 2);
-    fieldBuffer.writeInt16BE(length);
-    fieldBuffer.write(fieldValue, 2);
-    return fieldBuffer;
-}
-
-// Create a new CONNECT message based on modified fields
-function newConnect(data) {
-    var newHeader = data.subarray(varHeaderStart, varHeaderEnd);
-    var newLength = newHeader.length;
-    var newFields = [newHeader];
-
-    // 
-    if (connectFlags & 128) {
-        var userBuf = setField(username);
-        newLength += userBuf.length;
-        newFields.push(userBuf);
-    }
-
-    if (connectFlags & 64) {
-        var passBuf = setField(password);
-        newLength += passBuf.length;
-        newFields.push(passBuf);
-    }
-
-    newFields.unshift(Buffer.from(setField("MQTT").toString('hex') + "05" + connectFlags.toString(16), 'hex'));
-    newLength += 8;
-
-    newFields.unshift(Buffer.from(packetTypeFlags.toString(16) + encodeLength(newLength), 'hex'));
-
-    return Buffer.concat(newFields);
-}
-
-// parse MQTT CONNECT packet
-function parseConnect(s, data) {
-
-    // Length of Variable Header plus length of the Payload.
-    var remainingLength = decodeLength(data);
-    var expectedLength = remainingLength + offset;
-
-    s.log("Payload Length = " + remainingLength);
-
-    // Verify protocol name and version
-    // Abort if not MQTTv5
-    if (cutField(data) != "MQTT" || data[offset++] != 5) {
-        s.log("ABORT: Packet not MQTTv5");
-        throw new Error("Connection Rejected");
-    }
-
-    // Retrieve Connect Flags and Keep Alive
-    connectFlags = data[offset++];
-    s.log("Connect Flags = " + connectFlags.toString(2));
-
-    if (connectFlags & 2) s.log("Clean Start flag is set");
-
-    varHeaderStart = offset;
-
-    s.log("Keep Alive = " + getInt16(data));
-
-    // Skip over CONNECT Properties
-    var propLength = decodeLength(data);
-    s.log("CONNECT Properties  = " + propLength + " bytes");
-    offset += propLength;
-
-    // Get Client Identifier
-    clientID = cutField(data);
-    s.log("ClientId value   = " + clientID);
-
-    // Skip Will Message
-    if (connectFlags & 4) {
-        propLength = decodeLength(data);
-        s.log("Will Properties  = " + propLength + " bytes");
-        offset += propLength;
-
-        // Make these variables global to share with NGINX
-        var willTopic = cutField(data);
-        s.log("Will Topic = " + willTopic);
-
-        var willMsg = cutField(data);
-        s.log("Will Payload = " + willMsg);
-    }
-
-    varHeaderEnd = offset;
-
-    // Look for existing username/password
-    if (connectFlags & 128) {
-        s.log("Client User Name = " + cutField(data));
-    }
-
-    if (connectFlags & 64) {
-        password = cutField(data);
-        s.log("Client Password = " + password);
-    }
-    s.log("Expected length: " + expectedLength + " Parsed Length: " + offset);
 }
 
 export default { filterMQTT, prereadMQTT }

--- a/njs/proxy.js
+++ b/njs/proxy.js
@@ -28,6 +28,9 @@ function filterMQTT(s) {
 
                 s.log("MQTT packet type+flags = " + packet.typeFlags);
 
+                mqtt.parseProperties(s, packet, false);
+                s.log( "Properties: " + JSON.stringify( packet.props ));
+
                 // @ts-ignore
                 s.variables.clientid = packet.connect.clientID;
 

--- a/proxy.conf
+++ b/proxy.conf
@@ -8,6 +8,13 @@ stream {
   js_var $clientid;
   js_var $username;
 
+  # Run filter for all packets? Set to 0 to only filter CONNECT
+  js_var $filter_all 1;
+
+  # Replace connect packet by replacing username from client cert DN?
+  js_var $filter_connect_ssl_dn 1;
+
+
   log_format mqtt '$remote_addr $server_port [$time_local] $protocol $status $bytes_received ' 
                   '$bytes_sent $upstream_addr $clientid $username';
   


### PR DESCRIPTION
Expanded on the connect-car use-case to support older protocols, and routing based on other criteria, eg user-properties

* use a packet object to represent the MQTT request
* support multiple versions of MQTT (3.0, 3.1, and 5.0)
* enumerations for packet types and property types
* support for decoding properties in control packets and Wills
* additional function for optional decode of properties